### PR TITLE
Fix issue #1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,19 @@ source:
     - no_proj.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or osx]
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
     - g2clib
-    - mysql
+    - mysql-connector-c 6.1.*
     - libnetcdf 4.4.*
     - gcc
   run:
     - g2clib
-    - mysql
+    - mysql-connector-c 6.1.*
     - libnetcdf 4.4.*
     - libgcc  # [linux]
     - libgfortran  # [osx]


### PR DESCRIPTION
The old version was compile with `mysql 5.5.24` but it was unpinned. We can either pin to that version or move to the new packages. However, `mysql 5.7.20` does not ship the `mysql.h` (or it is not in the expected place) and `mysql-connector-c` seems to the the job.