### PR TITLE
depend on mysql-connector-cpp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - no_proj.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or osx]
   detect_binary_files_with_prefix: true
 
@@ -24,14 +24,14 @@ requirements:
     - make
   host:
     - g2clib
-    - mysql-connector-c 6.1.*
+    - mysql-connector-cpp
     - libnetcdf
     - libpng
     - zlib
     - jasper
   run:
     - g2clib
-    - mysql-connector-c 6.1.*
+    - mysql-connector-cpp
     - libnetcdf
     - libpng
     - zlib


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

it appears mysql-connector-c has been replaced by mysql-connector-cpp within conda-forge.

@conda-forge-admin, please rerender