### PR TITLE
enable AEC support

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,6 +20,8 @@ fortran_compiler_version:
 - '12'
 jasper:
 - '4'
+libaec:
+- '1'
 libnetcdf:
 - 4.9.2
 libpng:

--- a/.ci_support/migrations/jasper4.yaml
+++ b/.ci_support/migrations/jasper4.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1678798913
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-jasper:
-  - 4

--- a/.ci_support/migrations/libnetcdf491.yaml
+++ b/.ci_support/migrations/libnetcdf491.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libnetcdf:
-- 4.9.1
-migrator_ts: 1676063819.0284579

--- a/.ci_support/migrations/libnetcdf492.yaml
+++ b/.ci_support/migrations/libnetcdf492.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libnetcdf:
-- 4.9.2
-migrator_ts: 1678915697.6091654

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export LDFLAGS="-lg2c -ljasper -lnetcdf -lpng -lmysqlclient -lz -lm -fopenmp $LDFLAGS"
+export LDFLAGS="-lg2c -ljasper -lnetcdf -lpng -lmysqlclient -lsz -lz -lm -fopenmp $LDFLAGS"
 export CFLAGS="-I.. -I$PREFIX/include/mysql -fopenmp $CFLAGS"
 
 rm -rf g2clib-* wgrib2/{fnlist,Gctpc,gctpc_ll2xy,new_grid_lambertc}.[ch]

--- a/recipe/config.h
+++ b/recipe/config.h
@@ -1,4 +1,5 @@
 /* config.h */
+#define USE_AEC
 #define USE_REGEX
 #define USE_TIGGE
 #define USE_NAMES NCEP

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - jasper4.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win or osx]
   detect_binary_files_with_prefix: true
 
@@ -26,6 +26,7 @@ requirements:
   host:
     - g2clib
     - mysql-devel
+    - libaec
     - libnetcdf
     - libpng
     - zlib
@@ -33,6 +34,7 @@ requirements:
   run:
     - g2clib
     - mysql-libs
+    - libaec
     - libnetcdf
     - libpng
     - zlib


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I think this will help with wgrib2 being able to convert the latest ECMWF grib2 data.